### PR TITLE
Support named <template xh-name> for inline template definitions

### DIFF
--- a/tests/integration/named-templates-flow.test.js
+++ b/tests/integration/named-templates-flow.test.js
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const xhtmlx = require("../../xhtmlx.js");
+const { templateCache, scanNamedTemplates } = xhtmlx._internals;
+
+function flushPromises() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  global.fetch = jest.fn();
+  templateCache.clear();
+});
+
+afterEach(() => {
+  delete global.fetch;
+});
+
+describe("Named templates integration flow", () => {
+  test("xh-template resolves from named template without fetch", async () => {
+    global.fetch.mockImplementation((url) => {
+      if (url.includes("/api/")) {
+        return Promise.resolve({
+          ok: true, status: 200, statusText: "OK",
+          text: () => Promise.resolve(JSON.stringify({ name: "Alice", email: "alice@co.io" }))
+        });
+      }
+      return Promise.reject(new Error("Should not fetch template"));
+    });
+
+    document.body.innerHTML = `
+      <template xh-name="/templates/user.html">
+        <div class="user">
+          <span class="user-name" xh-text="name"></span>
+          <span class="user-email" xh-text="email"></span>
+        </div>
+      </template>
+
+      <div xh-get="/api/user/1" xh-trigger="load"
+           xh-template="/templates/user.html"
+           xh-target="#result">
+      </div>
+      <div id="result"></div>
+    `;
+
+    scanNamedTemplates();
+    xhtmlx.process(document.body);
+    await flushPromises();
+
+    expect(document.querySelector(".user-name").textContent).toBe("Alice");
+    expect(document.querySelector(".user-email").textContent).toBe("alice@co.io");
+
+    // Only the API was fetched, not the template
+    const fetchCalls = global.fetch.mock.calls.map(c => c[0]);
+    expect(fetchCalls.some(u => u.includes("/api/"))).toBe(true);
+    expect(fetchCalls.some(u => u.includes(".html"))).toBe(false);
+  });
+
+  test("named template with xh-each renders list", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true, status: 200, statusText: "OK",
+      text: () => Promise.resolve(JSON.stringify({
+        items: [{ title: "One" }, { title: "Two" }, { title: "Three" }]
+      }))
+    });
+
+    document.body.innerHTML = `
+      <template xh-name="/templates/list.html">
+        <ul>
+          <li xh-each="items" class="item" xh-text="title"></li>
+        </ul>
+      </template>
+
+      <div xh-get="/api/items" xh-trigger="load"
+           xh-template="/templates/list.html"
+           xh-target="#output">
+      </div>
+      <div id="output"></div>
+    `;
+
+    scanNamedTemplates();
+    xhtmlx.process(document.body);
+    await flushPromises();
+
+    const items = document.querySelectorAll(".item");
+    expect(items.length).toBe(3);
+    expect(items[0].textContent).toBe("One");
+    expect(items[2].textContent).toBe("Three");
+  });
+
+  test("mix of named and fetched templates works", async () => {
+    global.fetch.mockImplementation((url) => {
+      if (url.includes("/api/")) {
+        return Promise.resolve({
+          ok: true, status: 200, statusText: "OK",
+          text: () => Promise.resolve(JSON.stringify({ msg: "hello" }))
+        });
+      }
+      if (url.includes("/templates/remote.html")) {
+        return Promise.resolve({
+          ok: true, status: 200, statusText: "OK",
+          text: () => Promise.resolve('<span class="remote" xh-text="msg"></span>')
+        });
+      }
+      return Promise.reject(new Error("Unexpected fetch: " + url));
+    });
+
+    document.body.innerHTML = `
+      <template xh-name="/templates/local.html">
+        <span class="local" xh-text="msg"></span>
+      </template>
+
+      <div xh-get="/api/data" xh-trigger="load"
+           xh-template="/templates/local.html"
+           xh-target="#local-result">
+      </div>
+      <div id="local-result"></div>
+
+      <div xh-get="/api/data" xh-trigger="load"
+           xh-template="/templates/remote.html"
+           xh-target="#remote-result">
+      </div>
+      <div id="remote-result"></div>
+    `;
+
+    scanNamedTemplates();
+    xhtmlx.process(document.body);
+    await flushPromises();
+    await flushPromises();
+
+    expect(document.querySelector(".local").textContent).toBe("hello");
+    expect(document.querySelector(".remote").textContent).toBe("hello");
+  });
+
+  test("named error template works", async () => {
+    global.fetch.mockResolvedValue({
+      ok: false, status: 404, statusText: "Not Found",
+      text: () => Promise.resolve(JSON.stringify({ error: "not_found", message: "User not found" }))
+    });
+
+    document.body.innerHTML = `
+      <template xh-name="/templates/error.html">
+        <div class="err">
+          <span class="err-status" xh-text="status"></span>
+          <span class="err-msg" xh-text="body.message"></span>
+        </div>
+      </template>
+
+      <div xh-get="/api/missing" xh-trigger="load"
+           xh-error-template="/templates/error.html"
+           xh-target="#result">
+        <template><span>success</span></template>
+      </div>
+      <div id="result"></div>
+    `;
+
+    scanNamedTemplates();
+    xhtmlx.process(document.body);
+    await flushPromises();
+    await flushPromises();
+
+    expect(document.querySelector(".err-status").textContent).toBe("404");
+    expect(document.querySelector(".err-msg").textContent).toBe("User not found");
+  });
+});

--- a/tests/unit/named-templates.test.js
+++ b/tests/unit/named-templates.test.js
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const xhtmlx = require("../../xhtmlx.js");
+const { templateCache, config, scanNamedTemplates } = xhtmlx._internals;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  templateCache.clear();
+  config.templatePrefix = "";
+});
+
+afterEach(() => {
+  config.templatePrefix = "";
+});
+
+describe("Named templates (<template xh-name>)", () => {
+  test("scanNamedTemplates populates template cache from xh-name templates", () => {
+    document.body.innerHTML = `
+      <template xh-name="/templates/card.html">
+        <div class="card"><span xh-text="name"></span></div>
+      </template>
+    `;
+
+    scanNamedTemplates();
+
+    expect(templateCache.has("/templates/card.html")).toBe(true);
+  });
+
+  test("cached template content matches the template innerHTML", async () => {
+    document.body.innerHTML = `
+      <template xh-name="/templates/item.html">
+        <li xh-text="title"></li>
+      </template>
+    `;
+
+    scanNamedTemplates();
+
+    const html = await templateCache.get("/templates/item.html");
+    expect(html).toContain("xh-text");
+    expect(html).toContain("title");
+  });
+
+  test("multiple named templates are all cached", () => {
+    document.body.innerHTML = `
+      <template xh-name="/templates/a.html"><div>A</div></template>
+      <template xh-name="/templates/b.html"><div>B</div></template>
+      <template xh-name="/templates/c.html"><div>C</div></template>
+    `;
+
+    scanNamedTemplates();
+
+    expect(templateCache.has("/templates/a.html")).toBe(true);
+    expect(templateCache.has("/templates/b.html")).toBe(true);
+    expect(templateCache.has("/templates/c.html")).toBe(true);
+  });
+
+  test("templates without xh-name are ignored", () => {
+    document.body.innerHTML = `
+      <template xh-name="/templates/named.html"><div>Named</div></template>
+      <template><div>Unnamed</div></template>
+    `;
+
+    scanNamedTemplates();
+
+    expect(templateCache.size).toBe(1);
+  });
+
+  test("templatePrefix is prepended to cache key", () => {
+    config.templatePrefix = "/ui/v2";
+
+    document.body.innerHTML = `
+      <template xh-name="/templates/card.html"><div>Card</div></template>
+    `;
+
+    scanNamedTemplates();
+
+    expect(templateCache.has("/ui/v2/templates/card.html")).toBe(true);
+    expect(templateCache.has("/templates/card.html")).toBe(false);
+  });
+
+  test("named template takes priority over fetch", async () => {
+    global.fetch = jest.fn();
+
+    document.body.innerHTML = `
+      <template xh-name="/templates/card.html">
+        <span class="from-inline" xh-text="name"></span>
+      </template>
+    `;
+
+    scanNamedTemplates();
+
+    // Fetch the template — should resolve from cache, not call fetch
+    const { fetchTemplate } = xhtmlx._internals;
+    const html = await fetchTemplate("/templates/card.html");
+
+    expect(html).toContain("from-inline");
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    delete global.fetch;
+  });
+
+  test("missing template still falls back to fetch", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true, status: 200,
+      text: () => Promise.resolve("<span>fetched</span>")
+    });
+
+    document.body.innerHTML = `
+      <template xh-name="/templates/cached.html"><span>cached</span></template>
+    `;
+
+    scanNamedTemplates();
+
+    const { fetchTemplate } = xhtmlx._internals;
+    const html = await fetchTemplate("/templates/not-cached.html");
+
+    expect(html).toContain("fetched");
+    expect(global.fetch).toHaveBeenCalled();
+
+    delete global.fetch;
+  });
+
+  test("empty xh-name attribute is ignored", () => {
+    document.body.innerHTML = `
+      <template xh-name=""><div>Empty</div></template>
+      <template xh-name="/templates/real.html"><div>Real</div></template>
+    `;
+
+    scanNamedTemplates();
+
+    expect(templateCache.size).toBe(1);
+  });
+
+  test("scanNamedTemplates is idempotent", async () => {
+    document.body.innerHTML = `
+      <template xh-name="/templates/card.html"><div>V1</div></template>
+    `;
+
+    scanNamedTemplates();
+    scanNamedTemplates(); // Second call
+
+    const html = await templateCache.get("/templates/card.html");
+    expect(html).toContain("V1");
+  });
+
+  test("scanNamedTemplates is exposed on public API", () => {
+    expect(typeof xhtmlx.scanNamedTemplates).toBe("function");
+  });
+});

--- a/xhtmlx.js
+++ b/xhtmlx.js
@@ -2636,6 +2636,13 @@
     },
 
     /**
+     * Scan for <template xh-name="..."> and populate template cache.
+     * Called automatically on DOMContentLoaded. Call manually after
+     * dynamically adding named templates.
+     */
+    scanNamedTemplates: scanNamedTemplates,
+
+    /**
      * Interpolate a string using a data context.
      * @param {string}      str
      * @param {DataContext}  ctx
@@ -2741,6 +2748,7 @@
       performSwap: performSwap,
       buildRequestBody: buildRequestBody,
       fetchTemplate: fetchTemplate,
+      scanNamedTemplates: scanNamedTemplates,
       resolveTemplate: resolveTemplate,
       getSwapTarget: getSwapTarget,
       defaultTrigger: defaultTrigger,
@@ -2781,12 +2789,30 @@
   }
 
   // ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Named template scanning — <template xh-name="/path"> → cache
+  // ---------------------------------------------------------------------------
+
+  function scanNamedTemplates() {
+    if (typeof document === "undefined") return;
+    var named = document.querySelectorAll("template[xh-name]");
+    for (var i = 0; i < named.length; i++) {
+      var name = named[i].getAttribute("xh-name");
+      if (name) {
+        var prefixedName = config.templatePrefix ? config.templatePrefix + name : name;
+        templateCache.set(prefixedName, Promise.resolve(named[i].innerHTML));
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Auto-init on DOMContentLoaded (browser only)
   // ---------------------------------------------------------------------------
 
   if (typeof document !== "undefined" && document.addEventListener) {
     document.addEventListener("DOMContentLoaded", function () {
       injectDefaultCSS();
+      scanNamedTemplates();
       var rootCtx = new DataContext({});
       processNode(document.body, rootCtx, []);
       setupMutationObserver(rootCtx);


### PR DESCRIPTION
## Summary
Scan for `<template xh-name="/path">` on init and pre-populate the template cache. Eliminates network requests for templates defined inline in the page.

```html
<template xh-name="/templates/card.html">
  <div><span xh-text="name"></span></div>
</template>

<!-- Resolves instantly from cache, no fetch -->
<div xh-get="/api/users" xh-template="/templates/card.html">...</div>
```

- Inline templates take priority over fetch
- Missing templates fall back to fetch as usual
- Works with templatePrefix for versioned deployments
- Exposed as `xhtmlx.scanNamedTemplates()` for dynamic usage

## Test plan
- [x] 10 unit tests + 4 integration tests (all passing)
- [x] Lint clean, syntax valid

Closes #40