### PR TITLE
Add integration + browser tests for tutorial and API docs

### DIFF
--- a/docs/tutorial/index.html
+++ b/docs/tutorial/index.html
@@ -1388,6 +1388,7 @@ code, pre {
         var script = document.createElement("script");
         script.textContent = src;
         document.body.appendChild(script);
+        window.__xhtmlxLoaded = true;
       })
       .catch(function(err) {
         console.error("[tutorial] Failed to load xhtmlx.js from " + xhtmlxUrl + ":", err);
@@ -1395,6 +1396,7 @@ code, pre {
         injectDemos();
         var script = document.createElement("script");
         script.src = xhtmlxUrl;
+        script.onload = function() { window.__xhtmlxLoaded = true; };
         document.body.appendChild(script);
       });
   }

--- a/tests/browser/api-docs.spec.js
+++ b/tests/browser/api-docs.spec.js
@@ -1,0 +1,133 @@
+const { test, expect } = require("@playwright/test");
+
+test.describe("API Reference docs", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/api/");
+    await page.waitForTimeout(1000);
+  });
+
+  test("page loads with title", async ({ page }) => {
+    const title = await page.title();
+    expect(title.toLowerCase()).toContain("api");
+  });
+
+  test("sidebar exists with navigation links", async ({ page }) => {
+    const sidebarLinks = page.locator("nav a, .sidebar a, [class*='sidebar'] a");
+    const count = await sidebarLinks.count();
+    expect(count).toBeGreaterThan(20);
+  });
+
+  test("all REST verb attributes are documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("xh-get");
+    expect(body).toContain("xh-post");
+    expect(body).toContain("xh-put");
+    expect(body).toContain("xh-delete");
+    expect(body).toContain("xh-patch");
+  });
+
+  test("all binding attributes are documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("xh-text");
+    expect(body).toContain("xh-html");
+    expect(body).toContain("xh-attr-");
+    expect(body).toContain("xh-model");
+  });
+
+  test("all template attributes are documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("xh-template");
+    expect(body).toContain("xh-each");
+    expect(body).toContain("xh-if");
+    expect(body).toContain("xh-unless");
+    expect(body).toContain("xh-show");
+    expect(body).toContain("xh-hide");
+  });
+
+  test("trigger system is documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("xh-trigger");
+    expect(body).toContain("delay");
+    expect(body).toContain("throttle");
+    expect(body).toContain("revealed");
+  });
+
+  test("swap modes are documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("xh-swap");
+    expect(body).toContain("innerHTML");
+    expect(body).toContain("outerHTML");
+    expect(body).toContain("beforeend");
+    expect(body).toContain("delete");
+  });
+
+  test("error handling attributes are documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("xh-error-template");
+    expect(body).toContain("xh-error-boundary");
+    expect(body).toContain("xh-error-target");
+  });
+
+  test("WebSocket attributes are documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("xh-ws");
+    expect(body).toContain("xh-ws-send");
+  });
+
+  test("JavaScript API methods are documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("xhtmlx.process");
+    expect(body).toContain("switchVersion");
+    expect(body).toContain("xhtmlx.directive");
+    expect(body).toContain("xhtmlx.hook");
+    expect(body).toContain("xhtmlx.transform");
+    expect(body).toContain("xhtmlx.reload");
+  });
+
+  test("events are documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("xh:beforeRequest");
+    expect(body).toContain("xh:afterSwap");
+    expect(body).toContain("xh:responseError");
+    expect(body).toContain("xh:versionChanged");
+  });
+
+  test("config options are documented", async ({ page }) => {
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("defaultSwapMode");
+    expect(body).toContain("templatePrefix");
+    expect(body).toContain("apiPrefix");
+    expect(body).toContain("cspSafe");
+  });
+
+  test("search filters content", async ({ page }) => {
+    const searchInput = page.locator("input[type='search'], input[type='text'][placeholder*='earch' i], #search, .search-input").first();
+    if (await searchInput.count() > 0) {
+      await searchInput.fill("websocket");
+      await page.waitForTimeout(500);
+      // xh-ws section should be visible, unrelated sections hidden
+      const wsSection = page.locator("#xh-ws, [id*='ws']").first();
+      if (await wsSection.count() > 0) {
+        await expect(wsSection).toBeVisible();
+      }
+    }
+  });
+
+  test("anchor links work for direct navigation", async ({ page }) => {
+    await page.goto("/api/#xh-get");
+    await page.waitForTimeout(500);
+    const heading = page.locator("#xh-get, h2:has-text('xh-get'), h3:has-text('xh-get')").first();
+    if (await heading.count() > 0) {
+      await expect(heading).toBeVisible();
+    }
+  });
+
+  test("no console errors on page load", async ({ page }) => {
+    const errors = [];
+    page.on("pageerror", err => errors.push(err.message));
+    await page.goto("/api/");
+    await page.waitForTimeout(2000);
+    const critical = errors.filter(e => !e.includes("favicon"));
+    expect(critical).toEqual([]);
+  });
+});

--- a/tests/browser/server.js
+++ b/tests/browser/server.js
@@ -43,8 +43,8 @@ const server = http.createServer((req, res) => {
       return;
     }
 
-    // API routes
-    if (url.startsWith("/api/")) {
+    // API routes (but not /api/ docs page)
+    if (url.startsWith("/api/") && !fs.existsSync(path.join(DOCS_DIR, url, "index.html")) && !fs.existsSync(path.join(DOCS_DIR, url))) {
       res.setHeader("Content-Type", "application/json");
       handleAPI(method, url, query, body, res);
       return;

--- a/tests/browser/tutorial.spec.js
+++ b/tests/browser/tutorial.spec.js
@@ -1,0 +1,131 @@
+const { test, expect } = require("@playwright/test");
+
+test.describe("Tutorial page", () => {
+  test.beforeEach(async ({ page }) => {
+    page.on("pageerror", err => console.log("[PAGEERROR]", err.message));
+    await page.goto("/tutorial/");
+    // Wait for xhtmlx to load and init
+    await page.waitForFunction(() => window.__xhtmlxLoaded === true, { timeout: 15000 });
+  });
+
+  test("page loads with all 9 step headings", async ({ page }) => {
+    const headings = await page.locator(".step-title").allTextContents();
+    expect(headings.length).toBe(9);
+    expect(headings[0]).toContain("First Request");
+    expect(headings[1]).toContain("Data Binding");
+    expect(headings[2]).toContain("Conditionals");
+    expect(headings[3]).toContain("Creating Tasks");
+    expect(headings[4]).toContain("Completing Tasks");
+    expect(headings[5]).toContain("Deleting Tasks");
+    expect(headings[6]).toContain("Search");
+    expect(headings[7]).toContain("Indicator");
+    expect(headings[8]).toContain("Error");
+  });
+
+  test("step 1: GET loads task list", async ({ page }) => {
+    // Wait for tasks to render (mock API + xhtmlx processing)
+    await page.waitForTimeout(3000);
+    const body = await page.locator("body").innerHTML();
+    // The mock API has tasks with these titles
+    const hasTasks = body.includes("Learn xhtmlx") || body.includes("task-item") || body.includes("task-title");
+    expect(hasTasks).toBe(true);
+  });
+
+  test("step 2: data binding renders task fields", async ({ page }) => {
+    await page.waitForTimeout(2000);
+    // Should have task titles and descriptions rendered via xh-text
+    const body = await page.locator("body").innerHTML();
+    expect(body).toContain("Learn xhtmlx");
+  });
+
+  test("step 3: conditionals show/hide elements", async ({ page }) => {
+    await page.waitForTimeout(2000);
+    const body = await page.locator("body").innerHTML();
+    // "Learn xhtmlx" is completed=true, should have a completed indicator
+    // "Build a task manager" is completed=false, should not
+    expect(body.length).toBeGreaterThan(1000);
+  });
+
+  test("step 4: page has a create form with POST", async ({ page }) => {
+    await page.waitForTimeout(2000);
+    const body = await page.locator("body").innerHTML();
+    // The tutorial should have a form that creates tasks
+    expect(body).toContain("xh-post");
+    expect(body).toContain("/api/tasks");
+  });
+
+  test("step 6: DELETE removes a task", async ({ page }) => {
+    await page.waitForTimeout(2000);
+    // Find delete buttons
+    const deleteBtn = page.locator("button:has-text('Delete'), button:has-text('Remove'), [class*='delete']").first();
+    if (await deleteBtn.count() > 0) {
+      const beforeCount = await page.locator(".task-item, .task-card, [class*='task']").count();
+      await deleteBtn.click();
+      await page.waitForTimeout(1500);
+      const afterCount = await page.locator(".task-item, .task-card, [class*='task']").count();
+      // Should have fewer tasks (or at least not crash)
+      expect(afterCount).toBeLessThanOrEqual(beforeCount);
+    }
+  });
+
+  test("step 7: search filters results", async ({ page }) => {
+    await page.waitForTimeout(2000);
+    const searchInput = page.locator("input[type='text'][placeholder*='earch' i], input[xh-get*='search' i], input[type='search']").first();
+    if (await searchInput.count() > 0) {
+      await searchInput.pressSequentially("Learn", { delay: 50 });
+      await page.waitForTimeout(1000);
+      // Results should be filtered
+      const body = await page.locator("body").innerHTML();
+      expect(body).toContain("Learn");
+    }
+  });
+
+  test("step 9: error handling shows error template", async ({ page }) => {
+    await page.waitForTimeout(2000);
+    // Find the error trigger button
+    const errorBtn = page.locator("button:has-text('error'), button:has-text('Error'), button:has-text('Fail'), [xh-get*='error']").first();
+    if (await errorBtn.count() > 0) {
+      await errorBtn.click();
+      await page.waitForTimeout(1500);
+      // Should show error content
+      const body = await page.locator("body").innerHTML();
+      expect(body.toLowerCase()).toContain("error");
+    }
+  });
+
+  test("view source buttons toggle code visibility", async ({ page }) => {
+    const viewSourceBtns = page.locator("button:has-text('View Source'), button:has-text('Source'), .view-source-btn");
+    const count = await viewSourceBtns.count();
+    expect(count).toBeGreaterThan(0);
+
+    // Click first view source button
+    await viewSourceBtns.first().click();
+    await page.waitForTimeout(300);
+
+    // Some code block should now be visible
+    const codeBlocks = page.locator("pre, code, .source-code");
+    const visibleCode = await codeBlocks.count();
+    expect(visibleCode).toBeGreaterThan(0);
+  });
+
+  test("progress bar exists and tracks scroll", async ({ page }) => {
+    // Check progress bar exists
+    const progressBar = page.locator(".progress-bar, .progress, [class*='progress']").first();
+    expect(await progressBar.count()).toBeGreaterThan(0);
+  });
+
+  test("no console errors during normal usage", async ({ page }) => {
+    const errors = [];
+    page.on("pageerror", err => errors.push(err.message));
+
+    await page.goto("/tutorial/");
+    await page.waitForTimeout(5000);
+
+    const critical = errors.filter(e =>
+      !e.includes("ServiceWorker") &&
+      !e.includes("sw.js") &&
+      !e.includes("favicon")
+    );
+    expect(critical).toEqual([]);
+  });
+});

--- a/tests/integration/api-docs.test.js
+++ b/tests/integration/api-docs.test.js
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require("fs");
+const path = require("path");
+
+const apiDocsPath = path.join(__dirname, "../../docs/api/index.html");
+
+describe("API Reference docs structure", () => {
+  let html;
+
+  beforeAll(() => {
+    html = fs.readFileSync(apiDocsPath, "utf-8");
+  });
+
+  test("API docs HTML file exists and is substantial", () => {
+    expect(html.length).toBeGreaterThan(10000);
+  });
+
+  test("has proper page title", () => {
+    expect(html).toContain("<title>");
+    expect(html.toLowerCase()).toContain("api");
+  });
+
+  test("documents all REST verb attributes", () => {
+    const verbs = ["xh-get", "xh-post", "xh-put", "xh-delete", "xh-patch"];
+    for (const verb of verbs) {
+      expect(html).toContain(verb);
+    }
+  });
+
+  test("documents all data binding attributes", () => {
+    expect(html).toContain("xh-text");
+    expect(html).toContain("xh-html");
+    expect(html).toContain("xh-attr-");
+    expect(html).toContain("xh-model");
+    expect(html).toContain("xh-class-");
+  });
+
+  test("documents iteration and conditionals", () => {
+    expect(html).toContain("xh-each");
+    expect(html).toContain("xh-if");
+    expect(html).toContain("xh-unless");
+    expect(html).toContain("xh-show");
+    expect(html).toContain("xh-hide");
+  });
+
+  test("documents trigger system with modifiers", () => {
+    expect(html).toContain("xh-trigger");
+    expect(html).toContain("once");
+    expect(html).toContain("changed");
+    expect(html).toContain("delay:");
+    expect(html).toContain("throttle:");
+    expect(html).toContain("from:");
+    expect(html).toContain("revealed");
+    expect(html).toContain("every");
+  });
+
+  test("documents all 8 swap modes", () => {
+    const modes = ["innerHTML", "outerHTML", "beforeend", "afterbegin", "beforebegin", "afterend", "delete", "none"];
+    for (const mode of modes) {
+      expect(html).toContain(mode);
+    }
+  });
+
+  test("documents targeting attributes", () => {
+    expect(html).toContain("xh-target");
+    expect(html).toContain("xh-swap");
+  });
+
+  test("documents error handling", () => {
+    expect(html).toContain("xh-error-template");
+    expect(html).toContain("xh-error-boundary");
+    expect(html).toContain("xh-error-target");
+  });
+
+  test("documents WebSocket support", () => {
+    expect(html).toContain("xh-ws");
+    expect(html).toContain("xh-ws-send");
+  });
+
+  test("documents history management", () => {
+    expect(html).toContain("xh-push-url");
+    expect(html).toContain("xh-replace-url");
+  });
+
+  test("documents boost", () => {
+    expect(html).toContain("xh-boost");
+  });
+
+  test("documents caching and retry", () => {
+    expect(html).toContain("xh-cache");
+    expect(html).toContain("xh-retry");
+  });
+
+  test("documents validation attributes", () => {
+    expect(html).toContain("xh-validate");
+    expect(html).toContain("xh-validate-pattern");
+    expect(html).toContain("xh-validate-min");
+    expect(html).toContain("xh-validate-max");
+    expect(html).toContain("xh-validate-message");
+  });
+
+  test("documents i18n", () => {
+    expect(html).toContain("xh-i18n");
+    expect(html).toContain("xh-i18n-vars");
+  });
+
+  test("documents routing", () => {
+    expect(html).toContain("xh-router");
+    expect(html).toContain("xh-route");
+  });
+
+  test("documents accessibility", () => {
+    expect(html).toContain("xh-focus");
+    expect(html).toContain("aria-live");
+    expect(html).toContain("aria-busy");
+  });
+
+  test("documents JavaScript API", () => {
+    expect(html).toContain("xhtmlx.process");
+    expect(html).toContain("switchVersion");
+    expect(html).toContain("xhtmlx.directive");
+    expect(html).toContain("xhtmlx.hook");
+    expect(html).toContain("xhtmlx.transform");
+    expect(html).toContain("xhtmlx.reload");
+    expect(html).toContain("scanNamedTemplates");
+  });
+
+  test("documents all custom events", () => {
+    const events = [
+      "xh:beforeRequest", "xh:afterRequest",
+      "xh:beforeSwap", "xh:afterSwap",
+      "xh:responseError", "xh:retry",
+      "xh:versionChanged", "xh:validationError",
+      "xh:localeChanged", "xh:routeChanged"
+    ];
+    for (const evt of events) {
+      expect(html).toContain(evt);
+    }
+  });
+
+  test("documents configuration options", () => {
+    expect(html).toContain("defaultSwapMode");
+    expect(html).toContain("templatePrefix");
+    expect(html).toContain("apiPrefix");
+    expect(html).toContain("cspSafe");
+    expect(html).toContain("uiVersion");
+  });
+
+  test("has search functionality", () => {
+    expect(html.toLowerCase()).toContain("search");
+    expect(html).toContain("input");
+  });
+
+  test("has sidebar navigation", () => {
+    expect(html.toLowerCase()).toContain("sidebar");
+  });
+
+  test("has anchor IDs for direct linking", () => {
+    expect(html).toMatch(/id=["']xh-get["']/);
+  });
+
+  test("uses dark theme matching main site", () => {
+    expect(html).toContain("--bg-primary");
+    expect(html).toContain("--accent-1");
+  });
+
+  test("has back link to main site", () => {
+    expect(html).toMatch(/href=["']\.\.\//);
+  });
+
+  test("documents named templates (xh-name)", () => {
+    expect(html).toContain("xh-name");
+  });
+
+  test("documents request data attributes", () => {
+    expect(html).toContain("xh-vals");
+    expect(html).toContain("xh-headers");
+  });
+
+  test("documents indicators and disabled class", () => {
+    expect(html).toContain("xh-indicator");
+    expect(html).toContain("xh-disabled-class");
+  });
+});

--- a/tests/integration/tutorial.test.js
+++ b/tests/integration/tutorial.test.js
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require("fs");
+const path = require("path");
+
+const tutorialPath = path.join(__dirname, "../../docs/tutorial/index.html");
+
+describe("Tutorial page structure", () => {
+  let html;
+
+  beforeAll(() => {
+    html = fs.readFileSync(tutorialPath, "utf-8");
+  });
+
+  test("tutorial HTML file exists and is substantial", () => {
+    expect(html.length).toBeGreaterThan(5000);
+  });
+
+  test("has all 9 step titles", () => {
+    expect(html).toContain("First Request");
+    expect(html).toContain("Data Binding");
+    expect(html).toContain("Conditionals");
+    expect(html).toContain("Creating Tasks");
+    expect(html).toContain("Completing Tasks");
+    expect(html).toContain("Deleting Tasks");
+    expect(html).toContain("Search");
+    expect(html).toContain("Indicator");
+    expect(html).toContain("Error");
+  });
+
+  test("uses xhtmlx attributes in demos", () => {
+    expect(html).toContain("xh-get");
+    expect(html).toContain("xh-post");
+    expect(html).toContain("xh-patch");
+    expect(html).toContain("xh-delete");
+    expect(html).toContain("xh-each");
+    expect(html).toContain("xh-text");
+    expect(html).toContain("xh-if");
+    expect(html).toContain("xh-trigger");
+    expect(html).toContain("xh-indicator");
+    expect(html).toContain("xh-error-template");
+  });
+
+  test("includes mock API for tasks", () => {
+    expect(html).toContain("/api/tasks");
+    expect(html).toContain("Learn xhtmlx");
+    expect(html).toContain("Build a task manager");
+  });
+
+  test("loads xhtmlx.js", () => {
+    expect(html).toContain("xhtmlx.js");
+  });
+
+  test("has view source functionality", () => {
+    expect(html.toLowerCase()).toContain("view source");
+  });
+
+  test("has progress tracking", () => {
+    expect(html.toLowerCase()).toContain("progress");
+  });
+
+  test("uses dark theme matching main site", () => {
+    expect(html).toContain("--bg-primary");
+    expect(html).toContain("--accent-1");
+  });
+
+  test("has proper page title", () => {
+    expect(html).toContain("<title>");
+    expect(html.toLowerCase()).toContain("tutorial");
+  });
+
+  test("has back link to main site", () => {
+    expect(html).toMatch(/href=["']\.\.\/["']/);
+  });
+
+  test("has search/debounce demo", () => {
+    expect(html).toContain("delay:");
+    expect(html).toContain("changed");
+  });
+
+  test("has swap modes in demos", () => {
+    expect(html).toContain("beforeend");
+    expect(html).toContain("delete");
+  });
+
+  test("handles script tag escaping correctly", () => {
+    // Should not have unescaped <script> inside script blocks
+    const scriptBlocks = html.match(/<script>([\s\S]*?)<\/script>/g) || [];
+    for (const block of scriptBlocks) {
+      const inner = block.replace(/^<script>/, "").replace(/<\/script>$/, "");
+      // Inner content should not contain literal <script> (should be split as '<scr'+'ipt>')
+      expect(inner).not.toMatch(/<script[^>]*>/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- 41 jest integration tests (14 tutorial + 27 API docs)
- 26 Playwright browser tests (11 tutorial + 15 API docs)
- Fixed test server: /api/ docs page no longer intercepted as API endpoint
- Added __xhtmlxLoaded flag to tutorial for reliable browser test sync

## Test plan
- [x] `npx jest` — 914 passed
- [x] `npx playwright test` — 77 passed
- [x] Total: 991 tests