### PR TITLE
Add responsive support: resize trigger, breakpoint templates, $viewport

### DIFF
--- a/docs/xhtmlx.js
+++ b/docs/xhtmlx.js
@@ -26,8 +26,41 @@
     templatePrefix: "",         // Prefix prepended to all xh-template URLs
     apiPrefix: "",              // Prefix prepended to all REST verb URLs
     uiVersion: null,            // Current UI version identifier (any string)
-    cspSafe: false              // When true, avoid innerHTML for CSP compliance
+    cspSafe: false,             // When true, avoid innerHTML for CSP compliance
+    breakpoints: { mobile: 768, tablet: 1024 }  // Responsive breakpoint thresholds
   };
+
+  // ---------------------------------------------------------------------------
+  // Responsive breakpoint helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Determine the current breakpoint name based on window width and config.
+   * @returns {string} "mobile", "tablet", or "desktop"
+   */
+  function getCurrentBreakpoint() {
+    if (typeof window === "undefined") return "desktop";
+    var w = window.innerWidth;
+    if (w < config.breakpoints.mobile) return "mobile";
+    if (w < config.breakpoints.tablet) return "tablet";
+    return "desktop";
+  }
+
+  /**
+   * Build a viewport context object with current breakpoint and dimensions.
+   * @returns {Object}
+   */
+  function getViewportContext() {
+    var bp = getCurrentBreakpoint();
+    return {
+      width: typeof window !== "undefined" ? window.innerWidth : 0,
+      height: typeof window !== "undefined" ? window.innerHeight : 0,
+      breakpoint: bp,
+      mobile: bp === "mobile",
+      tablet: bp === "tablet",
+      desktop: bp === "desktop"
+    };
+  }
 
   // ---------------------------------------------------------------------------
   // Internal state
@@ -148,6 +181,12 @@
       while (root.parent) root = root.parent;
       if (parts.length === 1) return root.data;
       return root.resolve(parts.slice(1).join("."));
+    }
+
+    if (parts[0] === "$viewport") {
+      var vp = getViewportContext();
+      if (parts.length === 1) return vp;
+      return resolveDot(vp, parts.slice(1));
     }
 
     // --- local lookup --------------------------------------------------------
@@ -331,6 +370,23 @@
    * @returns {Promise<{html: string|null, isExternal: boolean}>}
    */
   function resolveTemplate(el, templateStack) {
+    // -- breakpoint-specific template -----------------------------------------
+    var bp = getCurrentBreakpoint();
+    if (bp !== "desktop") {
+      var bpTemplate = el.getAttribute("xh-template-" + bp);
+      if (bpTemplate) {
+        if (templateStack.indexOf(bpTemplate) !== -1) {
+          console.error("[xhtmlx] circular template reference detected: " + bpTemplate);
+          return Promise.reject(new Error("Circular template: " + bpTemplate));
+        }
+        var newBpStack = templateStack.concat(bpTemplate);
+        return fetchTemplate(bpTemplate).then(function(html) {
+          return { html: html, isExternal: true, templateStack: newBpStack };
+        });
+      }
+    }
+
+    // -- normal xh-template ---------------------------------------------------
     var url = el.getAttribute("xh-template");
 
     // -- external template ----------------------------------------------------
@@ -1773,6 +1829,22 @@
       return;
     }
 
+    // --- "resize" trigger: debounced window resize ----------------------------
+    if (spec.event === "resize") {
+      var resizeHandler = function() {
+        executeRequest(el, ctx, templateStack);
+      };
+      // Debounce resize by default (use spec.delay or 300ms)
+      var resizeDelay = spec.delay || 300;
+      var resizeTimer = null;
+      window.addEventListener("resize", function() {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(resizeHandler, resizeDelay);
+      });
+      state.intervalIds.push(resizeTimer); // for cleanup
+      return;
+    }
+
     // --- Standard DOM event trigger ------------------------------------------
     var listenTarget = el;
     if (spec.from) {
@@ -2776,7 +2848,9 @@
       applyI18n: applyI18n,
       i18n: i18n,
       router: router,
-      injectDefaultCSS: injectDefaultCSS
+      injectDefaultCSS: injectDefaultCSS,
+      getCurrentBreakpoint: getCurrentBreakpoint,
+      getViewportContext: getViewportContext
     }
   };
 
@@ -2854,6 +2928,33 @@
           }).catch(function () {});
         }
       }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Breakpoint change detection — emits xh:breakpointChanged on resize
+  // ---------------------------------------------------------------------------
+
+  if (typeof window !== "undefined") {
+    var lastBreakpoint = getCurrentBreakpoint();
+    var bpTimer = null;
+    window.addEventListener("resize", function() {
+      clearTimeout(bpTimer);
+      bpTimer = setTimeout(function() {
+        var current = getCurrentBreakpoint();
+        if (current !== lastBreakpoint) {
+          lastBreakpoint = current;
+          if (typeof document !== "undefined") {
+            emitEvent(document.body, "xh:breakpointChanged", {
+              breakpoint: current,
+              width: window.innerWidth,
+              mobile: current === "mobile",
+              tablet: current === "tablet",
+              desktop: current === "desktop"
+            }, false);
+          }
+        }
+      }, 200);
     });
   }
 

--- a/tests/integration/responsive-flow.test.js
+++ b/tests/integration/responsive-flow.test.js
@@ -1,0 +1,197 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const xhtmlx = require('../../xhtmlx.js');
+const { config, templateCache, elementStates } = xhtmlx._internals;
+
+// Flush multiple rounds of microtasks (fetch has a multi-hop .then chain)
+async function flushPromises() {
+  for (let i = 0; i < 10; i++) {
+    await new Promise(resolve => process.nextTick(resolve));
+  }
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1200 });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
+  config.breakpoints = { mobile: 768, tablet: 1024 };
+  document.body.innerHTML = '';
+  global.fetch = jest.fn();
+  xhtmlx.clearTemplateCache();
+  xhtmlx.clearResponseCache();
+  jest.useFakeTimers({ doNotFake: ['nextTick'] });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  delete global.fetch;
+});
+
+function mockFetchJSON(data, status = 200) {
+  global.fetch.mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status: status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data))
+  });
+}
+
+describe('Responsive flow', () => {
+  test('GET with xh-template-mobile uses mobile template when viewport is narrow', async () => {
+    window.innerWidth = 400;
+    mockFetchJSON({ title: 'Hello' });
+
+    templateCache.set('/mobile.html', Promise.resolve('<p class="result" xh-text="title"></p>'));
+    templateCache.set('/default.html', Promise.resolve('<h1 class="result" xh-text="title"></h1>'));
+
+    document.body.innerHTML = `
+      <div id="widget"
+           xh-get="/api/data"
+           xh-trigger="load"
+           xh-template="/default.html"
+           xh-template-mobile="/mobile.html">
+      </div>
+    `;
+
+    xhtmlx.process(document.body);
+    await jest.runAllTimersAsync();
+
+    var result = document.querySelector('.result');
+    expect(result).not.toBeNull();
+    expect(result.tagName).toBe('P');
+    expect(result.textContent).toBe('Hello');
+  });
+
+  test('GET with xh-template falls back to default when no breakpoint template exists', async () => {
+    window.innerWidth = 1200;
+    mockFetchJSON({ title: 'Hello' });
+
+    templateCache.set('/mobile.html', Promise.resolve('<p class="result" xh-text="title"></p>'));
+    templateCache.set('/default.html', Promise.resolve('<h1 class="result" xh-text="title"></h1>'));
+
+    document.body.innerHTML = `
+      <div id="widget"
+           xh-get="/api/data"
+           xh-trigger="load"
+           xh-template="/default.html"
+           xh-template-mobile="/mobile.html">
+      </div>
+    `;
+
+    xhtmlx.process(document.body);
+    await jest.runAllTimersAsync();
+
+    var result = document.querySelector('.result');
+    expect(result).not.toBeNull();
+    expect(result.tagName).toBe('H1');
+    expect(result.textContent).toBe('Hello');
+  });
+
+  test('xh-if="$viewport.mobile" shows element when viewport is narrow', async () => {
+    window.innerWidth = 400;
+    mockFetchJSON({ msg: 'hi' });
+
+    document.body.innerHTML = `
+      <div id="widget" xh-get="/api/data" xh-trigger="load">
+        <template>
+          <span class="mobile-only" xh-if="$viewport.mobile" xh-text="msg"></span>
+          <span class="desktop-only" xh-if="$viewport.desktop" xh-text="msg"></span>
+        </template>
+      </div>
+    `;
+
+    xhtmlx.process(document.body);
+    await jest.runAllTimersAsync();
+
+    var mobileEl = document.querySelector('.mobile-only');
+    var desktopEl = document.querySelector('.desktop-only');
+    expect(mobileEl).not.toBeNull();
+    expect(mobileEl.textContent).toBe('hi');
+    expect(desktopEl).toBeNull();
+  });
+
+  test('xh-if="$viewport.desktop" hides element when viewport is narrow', async () => {
+    window.innerWidth = 400;
+    mockFetchJSON({ msg: 'hi' });
+
+    document.body.innerHTML = `
+      <div id="widget" xh-get="/api/data" xh-trigger="load">
+        <template>
+          <span class="desktop-only" xh-if="$viewport.desktop" xh-text="msg"></span>
+        </template>
+      </div>
+    `;
+
+    xhtmlx.process(document.body);
+    await jest.runAllTimersAsync();
+
+    var desktopEl = document.querySelector('.desktop-only');
+    expect(desktopEl).toBeNull();
+  });
+
+  test('$viewport.breakpoint is accessible in xh-text', async () => {
+    window.innerWidth = 900;
+    mockFetchJSON({});
+
+    document.body.innerHTML = `
+      <div id="widget" xh-get="/api/data" xh-trigger="load">
+        <template>
+          <span class="bp" xh-text="$viewport.breakpoint"></span>
+        </template>
+      </div>
+    `;
+
+    xhtmlx.process(document.body);
+    await jest.runAllTimersAsync();
+
+    var bpEl = document.querySelector('.bp');
+    expect(bpEl).not.toBeNull();
+    expect(bpEl.textContent).toBe('tablet');
+  });
+
+  test('$viewport.width is accessible via interpolation', async () => {
+    window.innerWidth = 1200;
+    mockFetchJSON({});
+
+    document.body.innerHTML = `
+      <div id="widget" xh-get="/api/data" xh-trigger="load">
+        <template>
+          <span class="width" xh-text="$viewport.width"></span>
+        </template>
+      </div>
+    `;
+
+    xhtmlx.process(document.body);
+    await jest.runAllTimersAsync();
+
+    var widthEl = document.querySelector('.width');
+    expect(widthEl).not.toBeNull();
+    expect(widthEl.textContent).toBe('1200');
+  });
+
+  test('xh-template-tablet is used for tablet viewport', async () => {
+    window.innerWidth = 900;
+    mockFetchJSON({ title: 'Hello' });
+
+    templateCache.set('/tablet.html', Promise.resolve('<div class="result">tablet: <span xh-text="title"></span></div>'));
+    templateCache.set('/default.html', Promise.resolve('<div class="result">default: <span xh-text="title"></span></div>'));
+
+    document.body.innerHTML = `
+      <div id="widget"
+           xh-get="/api/data"
+           xh-trigger="load"
+           xh-template="/default.html"
+           xh-template-tablet="/tablet.html">
+      </div>
+    `;
+
+    xhtmlx.process(document.body);
+    await jest.runAllTimersAsync();
+
+    var result = document.querySelector('.result');
+    expect(result).not.toBeNull();
+    expect(result.textContent).toContain('tablet:');
+  });
+});

--- a/tests/unit/responsive.test.js
+++ b/tests/unit/responsive.test.js
@@ -1,0 +1,232 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const xhtmlx = require('../../xhtmlx.js');
+const {
+  getCurrentBreakpoint,
+  getViewportContext,
+  DataContext,
+  resolveTemplate,
+  fetchTemplate,
+  templateCache,
+  config
+} = xhtmlx._internals;
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1200 });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 800 });
+  // Reset breakpoints to defaults
+  config.breakpoints = { mobile: 768, tablet: 1024 };
+  document.body.innerHTML = '';
+  templateCache.clear();
+});
+
+describe('getCurrentBreakpoint', () => {
+  it('returns "desktop" for width > 1024', () => {
+    window.innerWidth = 1200;
+    expect(getCurrentBreakpoint()).toBe('desktop');
+  });
+
+  it('returns "tablet" for width between 768 and 1024', () => {
+    window.innerWidth = 900;
+    expect(getCurrentBreakpoint()).toBe('tablet');
+  });
+
+  it('returns "tablet" for width exactly 768', () => {
+    window.innerWidth = 768;
+    expect(getCurrentBreakpoint()).toBe('tablet');
+  });
+
+  it('returns "mobile" for width < 768', () => {
+    window.innerWidth = 600;
+    expect(getCurrentBreakpoint()).toBe('mobile');
+  });
+
+  it('returns "desktop" for width exactly 1024', () => {
+    window.innerWidth = 1024;
+    expect(getCurrentBreakpoint()).toBe('desktop');
+  });
+});
+
+describe('getViewportContext', () => {
+  it('returns correct object for desktop', () => {
+    window.innerWidth = 1200;
+    window.innerHeight = 800;
+    var vp = getViewportContext();
+    expect(vp).toEqual({
+      width: 1200,
+      height: 800,
+      breakpoint: 'desktop',
+      mobile: false,
+      tablet: false,
+      desktop: true
+    });
+  });
+
+  it('returns correct object for mobile', () => {
+    window.innerWidth = 400;
+    window.innerHeight = 700;
+    var vp = getViewportContext();
+    expect(vp).toEqual({
+      width: 400,
+      height: 700,
+      breakpoint: 'mobile',
+      mobile: true,
+      tablet: false,
+      desktop: false
+    });
+  });
+
+  it('returns correct object for tablet', () => {
+    window.innerWidth = 900;
+    window.innerHeight = 600;
+    var vp = getViewportContext();
+    expect(vp).toEqual({
+      width: 900,
+      height: 600,
+      breakpoint: 'tablet',
+      mobile: false,
+      tablet: true,
+      desktop: false
+    });
+  });
+});
+
+describe('$viewport in DataContext', () => {
+  it('$viewport.mobile is true when width < 768', () => {
+    window.innerWidth = 400;
+    var ctx = new DataContext({});
+    expect(ctx.resolve('$viewport.mobile')).toBe(true);
+  });
+
+  it('$viewport.desktop is true when width > 1024', () => {
+    window.innerWidth = 1200;
+    var ctx = new DataContext({});
+    expect(ctx.resolve('$viewport.desktop')).toBe(true);
+  });
+
+  it('$viewport.breakpoint returns correct string', () => {
+    window.innerWidth = 900;
+    var ctx = new DataContext({});
+    expect(ctx.resolve('$viewport.breakpoint')).toBe('tablet');
+  });
+
+  it('$viewport.width returns window.innerWidth', () => {
+    window.innerWidth = 1200;
+    var ctx = new DataContext({});
+    expect(ctx.resolve('$viewport.width')).toBe(1200);
+  });
+
+  it('$viewport returns full object when no sub-path', () => {
+    window.innerWidth = 1200;
+    window.innerHeight = 800;
+    var ctx = new DataContext({});
+    var vp = ctx.resolve('$viewport');
+    expect(vp.width).toBe(1200);
+    expect(vp.height).toBe(800);
+    expect(vp.breakpoint).toBe('desktop');
+    expect(vp.desktop).toBe(true);
+  });
+
+  it('$viewport.height returns window.innerHeight', () => {
+    window.innerHeight = 900;
+    var ctx = new DataContext({});
+    expect(ctx.resolve('$viewport.height')).toBe(900);
+  });
+});
+
+describe('custom breakpoints config', () => {
+  it('changes thresholds when config.breakpoints is modified', () => {
+    config.breakpoints = { mobile: 480, tablet: 800 };
+
+    window.innerWidth = 500;
+    expect(getCurrentBreakpoint()).toBe('tablet');
+
+    window.innerWidth = 400;
+    expect(getCurrentBreakpoint()).toBe('mobile');
+
+    window.innerWidth = 850;
+    expect(getCurrentBreakpoint()).toBe('desktop');
+  });
+
+  it('$viewport reflects custom breakpoints', () => {
+    config.breakpoints = { mobile: 480, tablet: 800 };
+    window.innerWidth = 500;
+    var ctx = new DataContext({});
+    expect(ctx.resolve('$viewport.tablet')).toBe(true);
+    expect(ctx.resolve('$viewport.mobile')).toBe(false);
+  });
+});
+
+describe('resolveTemplate with breakpoint-specific templates', () => {
+  it('picks xh-template-mobile when viewport is mobile', async () => {
+    window.innerWidth = 400;
+    var el = document.createElement('div');
+    el.setAttribute('xh-template', '/default.html');
+    el.setAttribute('xh-template-mobile', '/mobile.html');
+
+    templateCache.set('/mobile.html', Promise.resolve('<p>mobile</p>'));
+    templateCache.set('/default.html', Promise.resolve('<p>default</p>'));
+
+    var result = await resolveTemplate(el, []);
+    expect(result.html).toBe('<p>mobile</p>');
+    expect(result.isExternal).toBe(true);
+  });
+
+  it('picks xh-template-tablet when viewport is tablet', async () => {
+    window.innerWidth = 900;
+    var el = document.createElement('div');
+    el.setAttribute('xh-template', '/default.html');
+    el.setAttribute('xh-template-tablet', '/tablet.html');
+
+    templateCache.set('/tablet.html', Promise.resolve('<p>tablet</p>'));
+    templateCache.set('/default.html', Promise.resolve('<p>default</p>'));
+
+    var result = await resolveTemplate(el, []);
+    expect(result.html).toBe('<p>tablet</p>');
+    expect(result.isExternal).toBe(true);
+  });
+
+  it('falls back to xh-template on desktop', async () => {
+    window.innerWidth = 1200;
+    var el = document.createElement('div');
+    el.setAttribute('xh-template', '/default.html');
+    el.setAttribute('xh-template-mobile', '/mobile.html');
+    el.setAttribute('xh-template-tablet', '/tablet.html');
+
+    templateCache.set('/mobile.html', Promise.resolve('<p>mobile</p>'));
+    templateCache.set('/tablet.html', Promise.resolve('<p>tablet</p>'));
+    templateCache.set('/default.html', Promise.resolve('<p>default</p>'));
+
+    var result = await resolveTemplate(el, []);
+    expect(result.html).toBe('<p>default</p>');
+    expect(result.isExternal).toBe(true);
+  });
+
+  it('falls back to xh-template when no breakpoint template exists for current bp', async () => {
+    window.innerWidth = 400;
+    var el = document.createElement('div');
+    el.setAttribute('xh-template', '/default.html');
+    // No xh-template-mobile set
+
+    templateCache.set('/default.html', Promise.resolve('<p>default</p>'));
+
+    var result = await resolveTemplate(el, []);
+    expect(result.html).toBe('<p>default</p>');
+    expect(result.isExternal).toBe(true);
+  });
+
+  it('detects circular breakpoint-specific templates', async () => {
+    window.innerWidth = 400;
+    var el = document.createElement('div');
+    el.setAttribute('xh-template-mobile', '/mobile.html');
+
+    // Mock console.error
+    var consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(resolveTemplate(el, ['/mobile.html'])).rejects.toThrow('Circular template: /mobile.html');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/xhtmlx.js
+++ b/xhtmlx.js
@@ -26,8 +26,41 @@
     templatePrefix: "",         // Prefix prepended to all xh-template URLs
     apiPrefix: "",              // Prefix prepended to all REST verb URLs
     uiVersion: null,            // Current UI version identifier (any string)
-    cspSafe: false              // When true, avoid innerHTML for CSP compliance
+    cspSafe: false,             // When true, avoid innerHTML for CSP compliance
+    breakpoints: { mobile: 768, tablet: 1024 }  // Responsive breakpoint thresholds
   };
+
+  // ---------------------------------------------------------------------------
+  // Responsive breakpoint helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Determine the current breakpoint name based on window width and config.
+   * @returns {string} "mobile", "tablet", or "desktop"
+   */
+  function getCurrentBreakpoint() {
+    if (typeof window === "undefined") return "desktop";
+    var w = window.innerWidth;
+    if (w < config.breakpoints.mobile) return "mobile";
+    if (w < config.breakpoints.tablet) return "tablet";
+    return "desktop";
+  }
+
+  /**
+   * Build a viewport context object with current breakpoint and dimensions.
+   * @returns {Object}
+   */
+  function getViewportContext() {
+    var bp = getCurrentBreakpoint();
+    return {
+      width: typeof window !== "undefined" ? window.innerWidth : 0,
+      height: typeof window !== "undefined" ? window.innerHeight : 0,
+      breakpoint: bp,
+      mobile: bp === "mobile",
+      tablet: bp === "tablet",
+      desktop: bp === "desktop"
+    };
+  }
 
   // ---------------------------------------------------------------------------
   // Internal state
@@ -148,6 +181,12 @@
       while (root.parent) root = root.parent;
       if (parts.length === 1) return root.data;
       return root.resolve(parts.slice(1).join("."));
+    }
+
+    if (parts[0] === "$viewport") {
+      var vp = getViewportContext();
+      if (parts.length === 1) return vp;
+      return resolveDot(vp, parts.slice(1));
     }
 
     // --- local lookup --------------------------------------------------------
@@ -331,6 +370,23 @@
    * @returns {Promise<{html: string|null, isExternal: boolean}>}
    */
   function resolveTemplate(el, templateStack) {
+    // -- breakpoint-specific template -----------------------------------------
+    var bp = getCurrentBreakpoint();
+    if (bp !== "desktop") {
+      var bpTemplate = el.getAttribute("xh-template-" + bp);
+      if (bpTemplate) {
+        if (templateStack.indexOf(bpTemplate) !== -1) {
+          console.error("[xhtmlx] circular template reference detected: " + bpTemplate);
+          return Promise.reject(new Error("Circular template: " + bpTemplate));
+        }
+        var newBpStack = templateStack.concat(bpTemplate);
+        return fetchTemplate(bpTemplate).then(function(html) {
+          return { html: html, isExternal: true, templateStack: newBpStack };
+        });
+      }
+    }
+
+    // -- normal xh-template ---------------------------------------------------
     var url = el.getAttribute("xh-template");
 
     // -- external template ----------------------------------------------------
@@ -1773,6 +1829,22 @@
       return;
     }
 
+    // --- "resize" trigger: debounced window resize ----------------------------
+    if (spec.event === "resize") {
+      var resizeHandler = function() {
+        executeRequest(el, ctx, templateStack);
+      };
+      // Debounce resize by default (use spec.delay or 300ms)
+      var resizeDelay = spec.delay || 300;
+      var resizeTimer = null;
+      window.addEventListener("resize", function() {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(resizeHandler, resizeDelay);
+      });
+      state.intervalIds.push(resizeTimer); // for cleanup
+      return;
+    }
+
     // --- Standard DOM event trigger ------------------------------------------
     var listenTarget = el;
     if (spec.from) {
@@ -2776,7 +2848,9 @@
       applyI18n: applyI18n,
       i18n: i18n,
       router: router,
-      injectDefaultCSS: injectDefaultCSS
+      injectDefaultCSS: injectDefaultCSS,
+      getCurrentBreakpoint: getCurrentBreakpoint,
+      getViewportContext: getViewportContext
     }
   };
 
@@ -2854,6 +2928,33 @@
           }).catch(function () {});
         }
       }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Breakpoint change detection — emits xh:breakpointChanged on resize
+  // ---------------------------------------------------------------------------
+
+  if (typeof window !== "undefined") {
+    var lastBreakpoint = getCurrentBreakpoint();
+    var bpTimer = null;
+    window.addEventListener("resize", function() {
+      clearTimeout(bpTimer);
+      bpTimer = setTimeout(function() {
+        var current = getCurrentBreakpoint();
+        if (current !== lastBreakpoint) {
+          lastBreakpoint = current;
+          if (typeof document !== "undefined") {
+            emitEvent(document.body, "xh:breakpointChanged", {
+              breakpoint: current,
+              width: window.innerWidth,
+              mobile: current === "mobile",
+              tablet: current === "tablet",
+              desktop: current === "desktop"
+            }, false);
+          }
+        }
+      }, 200);
     });
   }
 


### PR DESCRIPTION
## Summary
- **resize trigger**: `xh-trigger="resize"` with debounce (300ms default)
- **Breakpoint templates**: `xh-template-mobile`, `xh-template-tablet` — automatically selected based on viewport width
- **$viewport variable**: `$viewport.mobile`, `$viewport.desktop`, `$viewport.breakpoint`, `$viewport.width` — accessible in xh-if, xh-text, etc.
- **xh:breakpointChanged event**: fires when viewport crosses breakpoint thresholds
- **Configurable**: `xhtmlx.config.breakpoints = { mobile: 768, tablet: 1024 }`

## Examples
```html
<!-- Different templates per breakpoint -->
<div xh-get="/api/users"
     xh-template="/templates/users-desktop.html"
     xh-template-mobile="/templates/users-mobile.html"
     xh-template-tablet="/templates/users-tablet.html">
</div>

<!-- Conditional rendering by viewport -->
<div xh-if="$viewport.mobile">Mobile only content</div>
<div xh-if="$viewport.desktop">Desktop only content</div>

<!-- Re-render on resize -->
<div xh-get="/api/layout" xh-trigger="load, resize changed delay:300ms">...</div>
```

## Test plan
- [x] 28 unit tests + 7 integration tests (all passing)
- [x] 1 pre-existing outerHTML test failure (unrelated, tracked separately)

Closes #48