### PR TITLE
Add CLI migration tool: npx xhtmlx-migrate

### DIFF
--- a/bin/xhtmlx-migrate.js
+++ b/bin/xhtmlx-migrate.js
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+
+// ---------------------------------------------------------------------------
+// Migration rules per version pair
+// ---------------------------------------------------------------------------
+
+var MIGRATIONS = {
+  "1-2": {
+    description: "v1 to v2",
+    rules: [
+      // Example: attribute renames
+      { type: "rename-attr", from: "xh-bind", to: "xh-model", description: "xh-bind renamed to xh-model" },
+      // Example: value changes
+      { type: "rename-value", attr: "xh-swap", from: "replace", to: "outerHTML", description: "xh-swap='replace' renamed to 'outerHTML'" },
+      // Example: attribute split
+      { type: "rename-attr", from: "xh-loading", to: "xh-indicator", description: "xh-loading renamed to xh-indicator" },
+      // Example: new required attribute
+      { type: "add-attr-if-missing", ifHas: "xh-ws", attr: "xh-trigger", value: "message", description: "xh-ws now requires explicit xh-trigger" },
+    ]
+  },
+  "2-3": {
+    description: "v2 to v3",
+    rules: [
+      // Placeholder for future v3 migrations
+    ]
+  }
+};
+
+// Reverse migrations are auto-generated
+function getReverseMigration(fromTo) {
+  var forward = MIGRATIONS[fromTo];
+  if (!forward) return null;
+
+  return {
+    description: forward.description + " (reverse)",
+    rules: forward.rules.map(function(rule) {
+      if (rule.type === "rename-attr") {
+        return { type: "rename-attr", from: rule.to, to: rule.from, description: rule.description + " (reversed)" };
+      }
+      if (rule.type === "rename-value") {
+        return { type: "rename-value", attr: rule.attr, from: rule.to, to: rule.from, description: rule.description + " (reversed)" };
+      }
+      return rule;
+    })
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTML attribute transformer
+// ---------------------------------------------------------------------------
+
+function applyRule(html, rule) {
+  var changes = [];
+  var newHtml;
+
+  switch (rule.type) {
+    case "rename-attr": {
+      // Match the old attribute name in xh-* context
+      var attrRegex = new RegExp('(\\s)' + escapeRegex(rule.from) + '(\\s*=)', 'g');
+      newHtml = html.replace(attrRegex, function(match, pre, eq) {
+        changes.push(rule.description);
+        return pre + rule.to + eq;
+      });
+      // Also match without value (boolean attribute)
+      var boolRegex = new RegExp('(\\s)' + escapeRegex(rule.from) + '([\\s>])', 'g');
+      newHtml = newHtml.replace(boolRegex, function(match, pre, post) {
+        if (changes.length === 0) changes.push(rule.description);
+        return pre + rule.to + post;
+      });
+      return { html: newHtml, changes: changes };
+    }
+
+    case "rename-value": {
+      // Match attr="oldvalue"
+      var valRegex = new RegExp(
+        '(' + escapeRegex(rule.attr) + '\\s*=\\s*["\'])' + escapeRegex(rule.from) + '(["\'])',
+        'g'
+      );
+      newHtml = html.replace(valRegex, function(match, pre, post) {
+        changes.push(rule.description);
+        return pre + rule.to + post;
+      });
+      return { html: newHtml, changes: changes };
+    }
+
+    case "add-attr-if-missing": {
+      // Find elements that have ifHas but not attr
+      var hasRegex = new RegExp('<[^>]*' + escapeRegex(rule.ifHas) + '[^>]*>', 'g');
+      newHtml = html.replace(hasRegex, function(tag) {
+        if (tag.indexOf(rule.attr) === -1) {
+          changes.push(rule.description);
+          return tag.replace('>', ' ' + rule.attr + '="' + rule.value + '">');
+        }
+        return tag;
+      });
+      return { html: newHtml, changes: changes };
+    }
+
+    default:
+      return { html: html, changes: [] };
+  }
+}
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function migrateFile(filePath, rules, dryRun) {
+  var html = fs.readFileSync(filePath, "utf-8");
+  var originalHtml = html;
+  var allChanges = [];
+
+  for (var i = 0; i < rules.length; i++) {
+    var result = applyRule(html, rules[i]);
+    html = result.html;
+    allChanges = allChanges.concat(result.changes);
+  }
+
+  var changed = html !== originalHtml;
+
+  if (changed && !dryRun) {
+    fs.writeFileSync(filePath, html, "utf-8");
+  }
+
+  return {
+    file: filePath,
+    changed: changed,
+    changes: allChanges
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Simple recursive file finder (no external dependencies)
+// ---------------------------------------------------------------------------
+
+function findFiles(patterns) {
+  var files = [];
+  for (var p = 0; p < patterns.length; p++) {
+    var pattern = patterns[p];
+    if (fs.existsSync(pattern) && fs.statSync(pattern).isFile()) {
+      files.push(pattern);
+    } else if (fs.existsSync(pattern) && fs.statSync(pattern).isDirectory()) {
+      walkDir(pattern, files);
+    } else {
+      // Try as a simple glob: resolve parent dir and filter
+      var dir = path.dirname(pattern);
+      var ext = path.extname(pattern);
+      if (fs.existsSync(dir)) {
+        walkDir(dir, files, ext);
+      }
+    }
+  }
+  return files;
+}
+
+function walkDir(dir, files, extFilter) {
+  var entries = fs.readdirSync(dir);
+  for (var i = 0; i < entries.length; i++) {
+    var fullPath = path.join(dir, entries[i]);
+    var stat = fs.statSync(fullPath);
+    if (stat.isDirectory()) {
+      walkDir(fullPath, files, extFilter);
+    } else if (stat.isFile()) {
+      if (!extFilter || path.extname(fullPath) === extFilter) {
+        files.push(fullPath);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function printUsage() {
+  console.log("xhtmlx-migrate — Migrate HTML files between xhtmlx versions");
+  console.log("");
+  console.log("Usage:");
+  console.log("  npx xhtmlx-migrate --from=1 --to=2 <files...>");
+  console.log("  npx xhtmlx-migrate --from=2 --to=1 --reverse <files...>");
+  console.log("  npx xhtmlx-migrate --dry-run --from=1 --to=2 <files...>");
+  console.log("  npx xhtmlx-migrate --list-rules --from=1 --to=2");
+  console.log("");
+  console.log("Options:");
+  console.log("  --from=N       Source version number");
+  console.log("  --to=N         Target version number");
+  console.log("  --reverse      Apply migration in reverse (for rollback)");
+  console.log("  --dry-run      Preview changes without writing files");
+  console.log("  --list-rules   Show migration rules for the version pair");
+  console.log("  --help         Show this help");
+  console.log("");
+  console.log("Examples:");
+  console.log("  npx xhtmlx-migrate --from=1 --to=2 src/");
+  console.log("  npx xhtmlx-migrate --from=1 --to=2 index.html templates/");
+  console.log("  npx xhtmlx-migrate --dry-run --from=1 --to=2 **/*.html");
+}
+
+function parseArgs(args) {
+  var opts = { from: null, to: null, reverse: false, dryRun: false, listRules: false, help: false, files: [] };
+
+  for (var i = 0; i < args.length; i++) {
+    var arg = args[i];
+    if (arg === "--help" || arg === "-h") opts.help = true;
+    else if (arg === "--reverse") opts.reverse = true;
+    else if (arg === "--dry-run") opts.dryRun = true;
+    else if (arg === "--list-rules") opts.listRules = true;
+    else if (arg.indexOf("--from=") === 0) opts.from = arg.slice(7);
+    else if (arg.indexOf("--to=") === 0) opts.to = arg.slice(5);
+    else opts.files.push(arg);
+  }
+
+  return opts;
+}
+
+function main() {
+  var args = process.argv.slice(2);
+  var opts = parseArgs(args);
+
+  if (opts.help || args.length === 0) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (!opts.from || !opts.to) {
+    console.error("Error: --from and --to are required");
+    printUsage();
+    process.exit(1);
+  }
+
+  var migrationKey = opts.from + "-" + opts.to;
+  var migration = opts.reverse ? getReverseMigration(migrationKey) : MIGRATIONS[migrationKey];
+
+  if (!migration) {
+    // Try reverse key
+    var reverseKey = opts.to + "-" + opts.from;
+    if (opts.reverse && MIGRATIONS[reverseKey]) {
+      migration = MIGRATIONS[reverseKey];
+    }
+    if (!migration) {
+      console.error("Error: No migration rules found for v" + opts.from + " -> v" + opts.to + (opts.reverse ? " (reverse)" : ""));
+      console.error("Available migrations: " + Object.keys(MIGRATIONS).map(function(k) { return "v" + k.replace("-", " -> v"); }).join(", "));
+      process.exit(1);
+    }
+  }
+
+  if (opts.listRules) {
+    console.log("Migration: " + migration.description);
+    console.log("Rules (" + migration.rules.length + "):");
+    for (var r = 0; r < migration.rules.length; r++) {
+      var rule = migration.rules[r];
+      console.log("  " + (r + 1) + ". [" + rule.type + "] " + rule.description);
+    }
+    process.exit(0);
+  }
+
+  if (opts.files.length === 0) {
+    console.error("Error: No files specified");
+    printUsage();
+    process.exit(1);
+  }
+
+  // Find all matching files
+  var files = findFiles(opts.files);
+
+  if (files.length === 0) {
+    console.error("Error: No HTML files found matching the given patterns");
+    process.exit(1);
+  }
+
+  console.log("xhtmlx-migrate: v" + opts.from + " -> v" + opts.to + (opts.reverse ? " (reverse)" : "") + (opts.dryRun ? " [DRY RUN]" : ""));
+  console.log("Processing " + files.length + " file(s)...");
+  console.log("");
+
+  var totalChanged = 0;
+  var totalChanges = 0;
+
+  for (var f = 0; f < files.length; f++) {
+    var result = migrateFile(files[f], migration.rules, opts.dryRun);
+    if (result.changed) {
+      totalChanged++;
+      totalChanges += result.changes.length;
+      console.log("  " + (opts.dryRun ? "[would change]" : "[changed]") + " " + result.file);
+      for (var c = 0; c < result.changes.length; c++) {
+        console.log("    - " + result.changes[c]);
+      }
+    }
+  }
+
+  console.log("");
+  console.log("Summary:");
+  console.log("  Files scanned:  " + files.length);
+  console.log("  Files changed:  " + totalChanged);
+  console.log("  Total changes:  " + totalChanges);
+
+  if (opts.dryRun && totalChanged > 0) {
+    console.log("");
+    console.log("Run without --dry-run to apply changes.");
+  }
+
+  process.exit(totalChanged > 0 && opts.dryRun ? 0 : 0);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -7,11 +7,15 @@
   "browser": "xhtmlx.js",
   "unpkg": "xhtmlx.min.js",
   "jsdelivr": "xhtmlx.min.js",
+  "bin": {
+    "xhtmlx-migrate": "./bin/xhtmlx-migrate.js"
+  },
   "files": [
     "xhtmlx.js",
     "xhtmlx.d.ts",
     "xhtmlx.min.js",
     "xhtmlx.min.js.map",
+    "bin/",
     "README.md",
     "LICENSE"
   ],

--- a/tests/integration/responsive-flow.test.js
+++ b/tests/integration/responsive-flow.test.js
@@ -3,14 +3,8 @@
  */
 
 const xhtmlx = require('../../xhtmlx.js');
-const { config, templateCache, elementStates } = xhtmlx._internals;
+const { config, templateCache } = xhtmlx._internals;
 
-// Flush multiple rounds of microtasks (fetch has a multi-hop .then chain)
-async function flushPromises() {
-  for (let i = 0; i < 10; i++) {
-    await new Promise(resolve => process.nextTick(resolve));
-  }
-}
 
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1200 });

--- a/tests/unit/migrate-cli.test.js
+++ b/tests/unit/migrate-cli.test.js
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment node
+ */
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const CLI = path.join(__dirname, "../../bin/xhtmlx-migrate.js");
+
+function run(args) {
+  return execSync("node " + CLI + " " + args, { encoding: "utf-8", timeout: 10000 }).trim();
+}
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "xhtmlx-migrate-"));
+}
+
+describe("xhtmlx-migrate CLI", () => {
+  test("--help shows usage", () => {
+    const out = run("--help");
+    expect(out).toContain("xhtmlx-migrate");
+    expect(out).toContain("--from");
+    expect(out).toContain("--to");
+    expect(out).toContain("--dry-run");
+  });
+
+  test("no args shows usage", () => {
+    const out = run("");
+    expect(out).toContain("Usage");
+  });
+
+  test("--list-rules shows migration rules", () => {
+    const out = run("--from=1 --to=2 --list-rules");
+    expect(out).toContain("Migration:");
+    expect(out).toContain("Rules");
+    expect(out).toContain("xh-bind");
+  });
+
+  test("missing --from/--to shows error", () => {
+    try {
+      run("--from=1 somefile.html");
+      expect(true).toBe(false); // should not reach
+    } catch (e) {
+      expect(e.stderr || e.message).toContain("--from and --to are required");
+    }
+  });
+
+  test("invalid version pair shows error", () => {
+    try {
+      run("--from=99 --to=100 somefile.html");
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.stderr || e.message).toContain("No migration rules");
+    }
+  });
+
+  test("--dry-run does not modify files", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "test.html");
+    fs.writeFileSync(file, '<div xh-bind="name"></div>');
+
+    const out = run("--from=1 --to=2 --dry-run " + file);
+    expect(out).toContain("[would change]");
+    expect(out).toContain("xh-bind renamed to xh-model");
+
+    // File should NOT be modified
+    const content = fs.readFileSync(file, "utf-8");
+    expect(content).toContain("xh-bind");
+    expect(content).not.toContain("xh-model");
+
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("renames xh-bind to xh-model", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "test.html");
+    fs.writeFileSync(file, '<input xh-bind="username">');
+
+    const out = run("--from=1 --to=2 " + file);
+    expect(out).toContain("[changed]");
+
+    const content = fs.readFileSync(file, "utf-8");
+    expect(content).toContain("xh-model");
+    expect(content).not.toContain("xh-bind");
+
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("renames xh-swap='replace' to 'outerHTML'", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "test.html");
+    fs.writeFileSync(file, '<div xh-get="/api" xh-swap="replace"></div>');
+
+    run("--from=1 --to=2 " + file);
+
+    const content = fs.readFileSync(file, "utf-8");
+    expect(content).toContain('xh-swap="outerHTML"');
+    expect(content).not.toContain('xh-swap="replace"');
+
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("renames xh-loading to xh-indicator", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "test.html");
+    fs.writeFileSync(file, '<div xh-get="/api" xh-loading="#spinner"></div>');
+
+    run("--from=1 --to=2 " + file);
+
+    const content = fs.readFileSync(file, "utf-8");
+    expect(content).toContain("xh-indicator");
+    expect(content).not.toContain("xh-loading");
+
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("--reverse undoes migration", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "test.html");
+    fs.writeFileSync(file, '<input xh-model="name">');
+
+    run("--from=1 --to=2 --reverse " + file);
+
+    const content = fs.readFileSync(file, "utf-8");
+    expect(content).toContain("xh-bind");
+    expect(content).not.toContain("xh-model");
+
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("processes multiple files in a directory", () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, "a.html"), '<div xh-bind="x"></div>');
+    fs.writeFileSync(path.join(dir, "b.html"), '<div xh-loading="#s"></div>');
+    fs.writeFileSync(path.join(dir, "c.txt"), 'not html');
+
+    const out = run("--from=1 --to=2 " + dir);
+    expect(out).toContain("Files changed:  2");
+
+    expect(fs.readFileSync(path.join(dir, "a.html"), "utf-8")).toContain("xh-model");
+    expect(fs.readFileSync(path.join(dir, "b.html"), "utf-8")).toContain("xh-indicator");
+
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("unchanged files are not reported", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "clean.html");
+    fs.writeFileSync(file, '<div xh-get="/api" xh-trigger="load"></div>');
+
+    const out = run("--from=1 --to=2 " + file);
+    expect(out).toContain("Files changed:  0");
+
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("applies multiple rules to same file", () => {
+    const dir = tmpDir();
+    const file = path.join(dir, "multi.html");
+    fs.writeFileSync(file, '<div xh-bind="name" xh-loading="#s" xh-swap="replace"></div>');
+
+    const out = run("--from=1 --to=2 " + file);
+
+    const content = fs.readFileSync(file, "utf-8");
+    expect(content).toContain("xh-model");
+    expect(content).toContain("xh-indicator");
+    expect(content).toContain('xh-swap="outerHTML"');
+    expect(out).toContain("Total changes:  3");
+
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  test("summary shows correct counts", () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, "a.html"), '<div xh-bind="x"></div>');
+    fs.writeFileSync(path.join(dir, "b.html"), '<div xh-get="/api"></div>');
+
+    const out = run("--from=1 --to=2 " + dir);
+    expect(out).toContain("Files scanned:  2");
+    expect(out).toContain("Files changed:  1");
+    expect(out).toContain("Total changes:  1");
+
+    fs.rmSync(dir, { recursive: true });
+  });
+});

--- a/tests/unit/responsive.test.js
+++ b/tests/unit/responsive.test.js
@@ -8,7 +8,6 @@ const {
   getViewportContext,
   DataContext,
   resolveTemplate,
-  fetchTemplate,
   templateCache,
   config
 } = xhtmlx._internals;


### PR DESCRIPTION
## Summary
CLI tool for migrating HTML files between xhtmlx versions.

```bash
npx xhtmlx-migrate --from=1 --to=2 src/          # migrate
npx xhtmlx-migrate --from=1 --to=2 --reverse src/ # rollback
npx xhtmlx-migrate --from=1 --to=2 --dry-run src/ # preview
npx xhtmlx-migrate --from=1 --to=2 --list-rules   # show rules
```

Migration rules for v1→v2:
- `xh-bind` → `xh-model`
- `xh-loading` → `xh-indicator`
- `xh-swap="replace"` → `xh-swap="outerHTML"`
- `xh-ws` requires explicit `xh-trigger`

Features: dry-run, reverse (rollback), directory recursion, multi-rule, summary report.

## Test plan
- [x] 14 unit tests (all CLI options, migrations, reverse, dry-run, multi-file)
- [x] 956 jest tests pass, lint clean
- [x] Waiting for CI

Closes #21