### PR TITLE
Perf: mark only top-level fragment children in markFragmentOwned

### DIFF
--- a/xhtmlx.js
+++ b/xhtmlx.js
@@ -1365,15 +1365,20 @@
    * @param {Element} processTarget – The container of new elements.
    */
   /**
-   * Mark all elements in a DocumentFragment as owned by xhtmlx so that
-   * MutationObserver skips them (they'll be processed via processNode
+   * Mark top-level element children in a DocumentFragment as owned by xhtmlx
+   * so that MutationObserver skips them (they'll be processed via processNode
    * with the correct data context instead of the root context).
+   *
+   * Only top-level children need marking because the MutationObserver receives
+   * them as addedNodes and checks data-xh-owned on each one directly.
    */
   function markFragmentOwned(fragment) {
-    if (!fragment || !fragment.querySelectorAll) return;
-    var els = fragment.querySelectorAll("*");
-    for (var i = 0; i < els.length; i++) {
-      els[i].setAttribute("data-xh-owned", "");
+    if (!fragment) return;
+    var children = fragment.childNodes;
+    for (var i = 0; i < children.length; i++) {
+      if (children[i].nodeType === 1 && children[i].setAttribute) {
+        children[i].setAttribute("data-xh-owned", "");
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Only mark top-level children of the DocumentFragment with `data-xh-owned` instead of every descendant via `querySelectorAll("*")`
- The MutationObserver receives top-level children as `addedNodes` and checks the attribute directly on them — descendants don't need individual markers
- Eliminates N unnecessary `setAttribute` calls per swap operation (where N = total descendant elements in the template)

Fixes #69

## Test plan
- [x] All 956 tests pass
- [x] ESLint clean