### PR TITLE
fix: use OIDC auth for npm publish by stripping stale _authToken

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,6 @@ jobs:
       - run: npx terser xhtmlx.js -o xhtmlx.min.js --compress --mangle --source-map "filename='xhtmlx.min.js.map',url='xhtmlx.min.js.map'"
       - run: npm pack --dry-run
       - name: Publish with OIDC provenance
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG" 2>/dev/null || true
+          npm publish --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,5 @@ jobs:
       - run: npm pack --dry-run
       - name: Publish with OIDC provenance
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Strip `_authToken` from `.npmrc` before `npm publish` so npm uses OIDC authentication instead of the stale token injected by `actions/setup-node`
- This is how v0.3.0 was successfully published; the workflow rewrite lost the `sed` strip step, breaking all publishes since v0.3.1

## After merging

Recreate releases to trigger the fixed publish workflow:
```bash
for tag in v0.3.1 v0.4.0 v0.4.1; do
  gh release delete $tag --repo teryxjs/xhtmlx --yes
  gh release create $tag --repo teryxjs/xhtmlx --title "$tag" --generate-notes --target $tag
done
```

## Test plan
- [x] Verified this matches the approach used by the successful v0.3.0 publish run